### PR TITLE
Add in express/fastlane workflow

### DIFF
--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -30,17 +30,6 @@ outputs: []
 
 steps:
 
-  notify_participants:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/notification_email.cwl
-    in:
-      - id: submissionid
-        source: "#submissionId"
-      - id: synapse_config
-        source: "#synapseConfig"
-      - id: parentid
-        source: "#submitterUploadSynId"
-    out: []
-
   get_docker_submission:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_submission.cwl
     in:

--- a/express_workflow.cwl
+++ b/express_workflow.cwl
@@ -1,0 +1,214 @@
+#!/usr/bin/env cwl-runner
+#
+# Express lane workflow
+# Inputs:
+#   submissionId: ID of the Synapse submission to process
+#   adminUploadSynId: ID of a folder accessible only to the submission queue administrator
+#   submitterUploadSynId: ID of a folder accessible to the submitter
+#   workflowSynapseId:  ID of the Synapse entity containing a reference to the workflow file(s)
+#
+cwlVersion: v1.0
+class: Workflow
+
+requirements:
+  - class: StepInputExpressionRequirement
+
+inputs:
+  - id: submissionId
+    type: int
+  - id: adminUploadSynId
+    type: string
+  - id: submitterUploadSynId
+    type: string
+  - id: workflowSynapseId
+    type: string
+  - id: synapseConfig
+    type: File
+
+# there are no output at the workflow engine level.  Everything is uploaded to Synapse
+outputs: []
+
+steps:
+
+  get_docker_submission:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out:
+      - id: filepath
+      - id: docker_repository
+      - id: docker_digest
+      - id: entity_id
+      - id: entity_type
+      - id: results
+
+  get_docker_config:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_docker_config.cwl
+    in:
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: 
+      - id: docker_registry
+      - id: docker_authentication
+
+#  download_goldstandard:
+#    run: https://raw.githubusercontent.com/Sage-Bionetworks/synapse-client-cwl-tools/v0.1/synapse-get-tool.cwl
+#    in:
+#      - id: synapseid
+#        #This is a dummy syn id, replace when you use your own workflow
+#        valueFrom: "syn18081597"
+#      - id: synapse_config
+#        source: "#synapseConfig"
+#    out:
+#      - id: filepath
+
+  validate_docker:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/validate_docker.cwl
+    in:
+      - id: docker_repository
+        source: "#get_docker_submission/docker_repository"
+      - id: docker_digest
+        source: "#get_docker_submission/docker_digest"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out:
+      - id: results
+      - id: status
+      - id: invalid_reasons
+
+  annotate_docker_validation_with_output:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#validate_docker/results"
+      - id: to_public
+        default: true
+      - id: force_change_annotation_acl
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: [finished]
+
+  run_docker:
+    run: run_docker.cwl
+    in:
+      - id: docker_repository
+        source: "#get_docker_submission/docker_repository"
+      - id: docker_digest
+        source: "#get_docker_submission/docker_digest"
+      - id: submissionid
+        source: "#submissionId"
+      - id: docker_registry
+        source: "#get_docker_config/docker_registry"
+      - id: docker_authentication
+        source: "#get_docker_config/docker_authentication"
+      - id: status
+        source: "#validate_docker/status"
+      - id: parentid
+        source: "#submitterUploadSynId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: input_dir
+        # Replace this with correct datapath
+        valueFrom: "/root/simon/less-images"
+      - id: docker_script
+        default:
+          class: File
+          location: "run_docker.py"
+    out:
+      - id: predictions
+
+  upload_results:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/upload_to_synapse.cwl
+    in:
+      - id: infile
+        source: "#run_docker/predictions"
+      - id: parentid
+        source: "#adminUploadSynId"
+      - id: used_entity
+        source: "#get_docker_submission/entity_id"
+      - id: executed_entity
+        source: "#workflowSynapseId"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out:
+      - id: uploaded_fileid
+      - id: uploaded_file_version
+      - id: results
+
+  annotate_docker_upload_results:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#upload_results/results"
+      - id: to_public
+        default: true
+      - id: force_change_annotation_acl
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: previous_annotation_finished
+        source: "#annotate_docker_validation_with_output/finished"
+    out: [finished]
+i w
+  validation:
+    run: validate.cwl
+    in:
+      - id: inputfile
+        source: "#run_docker/predictions"
+      # Entity type isn't passed in because docker file prediction files are passed
+      # From the docker run command
+      - id: entity_type
+        valueFrom: "none"
+    out:
+      - id: results
+      - id: status
+      - id: invalid_reasons
+  
+  validation_email:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/validate_email.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: status
+        source: "#validation/status"
+      - id: invalid_reasons
+        source: "#validation/invalid_reasons"
+    out: [finished]
+
+  annotate_validation_with_output:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#validation/results"
+      - id: to_public
+        default: true
+      - id: force_change_annotation_acl
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: previous_annotation_finished
+        source: "#annotate_docker_upload_results/finished"
+    out: [finished]
+
+  check_status:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/check_status.cwl
+    in:
+      - id: status
+        source: "#validation/status"
+      - id: previous_annotation_finished
+        source: "#annotate_validation_with_output/finished"
+      - id: previous_email_finished
+        source: "#validation_email/finished"
+    out: [finished]


### PR DESCRIPTION
* Update WorkflowOrchestrator by doing (updated notification email sent by this process, so we can remove the step in the workflow)
```
docker pull sagebionetworks/synapse-workflow-orchestrator:1.1
```
* Add express lane workflow: Notice how there is no scoring, because the purpose of this workflow is just to make sure participants models create a correctly formatted prediction file.
* you will have to create an entity and evaluation queue just like you did for the other workflow to link them together in Synapse.