### PR TITLE
Participants submit to one queue and a workflow farms out jobs to different queues

### DIFF
--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -102,7 +102,7 @@ steps:
       - id: docker_authentication
         source: "#get_docker_config/docker_authentication"
       - id: status
-        source: "#validate_docker/status"
+        valueFrom: "VALIDATED"
       - id: parentid
         source: "#submitterUploadSynId"
       - id: synapse_config

--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -30,20 +30,15 @@ outputs: []
 
 steps:
 
-  get_docker_submission:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_submission.cwl
+  get_submissionid:
+    run: get_linked_submissionid.cwl
     in:
       - id: submissionid
         source: "#submissionId"
       - id: synapse_config
         source: "#synapseConfig"
     out:
-      - id: filepath
-      - id: docker_repository
-      - id: docker_digest
-      - id: entity_id
-      - id: entity_type
-      - id: results
+      - id: submissionid
 
   get_docker_config:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_docker_config.cwl
@@ -53,6 +48,19 @@ steps:
     out: 
       - id: docker_registry
       - id: docker_authentication
+
+  get_docker_submission:
+    run: get_submission_docker.cwl
+    in:
+      - id: submissionid
+        source: "#get_submissionid/submissionid"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out:
+      - id: docker_repository
+      - id: docker_digest
+      - id: entityid
+      - id: results
 
 #  download_goldstandard:
 #    run: https://raw.githubusercontent.com/Sage-Bionetworks/synapse-client-cwl-tools/v0.1/synapse-get-tool.cwl
@@ -65,27 +73,13 @@ steps:
 #    out:
 #      - id: filepath
 
-  validate_docker:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/validate_docker.cwl
-    in:
-      - id: docker_repository
-        source: "#get_docker_submission/docker_repository"
-      - id: docker_digest
-        source: "#get_docker_submission/docker_digest"
-      - id: synapse_config
-        source: "#synapseConfig"
-    out:
-      - id: results
-      - id: status
-      - id: invalid_reasons
-
-  annotate_docker_validation_with_output:
+  annotate_submission_main_userid:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
     in:
       - id: submissionid
         source: "#submissionId"
       - id: annotation_values
-        source: "#validate_docker/results"
+        source: "#get_docker_submission/results"
       - id: to_public
         default: true
       - id: force_change_annotation_acl

--- a/express_workflow.cwl
+++ b/express_workflow.cwl
@@ -108,7 +108,7 @@ steps:
       - id: docker_authentication
         source: "#get_docker_config/docker_authentication"
       - id: status
-        valueFrom: "VALIDATED"
+        valueFrom: "#validate_docker/status"
       - id: parentid
         source: "#submitterUploadSynId"
       - id: synapse_config

--- a/express_workflow.cwl
+++ b/express_workflow.cwl
@@ -108,7 +108,7 @@ steps:
       - id: docker_authentication
         source: "#get_docker_config/docker_authentication"
       - id: status
-        valueFrom: "#validate_docker/status"
+        source: "#validate_docker/status"
       - id: parentid
         source: "#submitterUploadSynId"
       - id: synapse_config

--- a/express_workflow.cwl
+++ b/express_workflow.cwl
@@ -108,7 +108,7 @@ steps:
       - id: docker_authentication
         source: "#get_docker_config/docker_authentication"
       - id: status
-        source: "#validate_docker/status"
+        valueFrom: "VALIDATED"
       - id: parentid
         source: "#submitterUploadSynId"
       - id: synapse_config

--- a/get_linked_submissionid.cwl
+++ b/get_linked_submissionid.cwl
@@ -1,0 +1,48 @@
+#!/usr/bin/env cwl-runner
+#
+# Extract the submitted Docker repository and Docker digest
+#
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: python
+
+inputs:
+  - id: submissionid
+    type: int
+  - id: synapse_config
+    type: File
+
+arguments:
+  - valueFrom: get_linked_submissionid.py
+  - valueFrom: $(inputs.submissionid)
+    prefix: -s
+  - valueFrom: $(inputs.synapse_config.path)
+    prefix: -c
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: get_linked_submissionid.py
+        entry: |
+          #!/usr/bin/env python
+          import synapseclient
+          import argparse
+          import json
+          import os
+          parser = argparse.ArgumentParser()
+          parser.add_argument("-s", "--submissionid", required=True, help="Submission ID")
+          parser.add_argument("-c", "--synapse_config", required=True, help="credentials file")
+          args = parser.parse_args()
+          syn = synapseclient.Synapse(configPath=args.synapse_config)
+          syn.login()
+          sub = syn.getSubmission(args.submissionid, downloadLocation=".")
+
+outputs:
+  - id: submissionid
+    type: int
+    outputBinding:
+      # This tool depends on the submission.json to be named submission.json
+      glob: submission.json
+      loadContents: true
+      outputEval: $(JSON.parse(self[0].contents)['submissionid'])

--- a/get_submission_docker.cwl
+++ b/get_submission_docker.cwl
@@ -1,0 +1,80 @@
+#!/usr/bin/env cwl-runner
+#
+# Extract the submitted Docker repository and Docker digest
+#
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: python
+
+inputs:
+  - id: submissionid
+    type: int
+  - id: synapse_config
+    type: File
+
+arguments:
+  - valueFrom: get_submission_docker.py
+  - valueFrom: $(inputs.submissionid)
+    prefix: -s
+  - valueFrom: results.json
+    prefix: -r
+  - valueFrom: output.json
+    prefix: -o
+  - valueFrom: $(inputs.synapse_config.path)
+    prefix: -c
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: get_submission_docker.py
+        entry: |
+          #!/usr/bin/env python
+          import synapseclient
+          import argparse
+          import json
+          import os
+          parser = argparse.ArgumentParser()
+          parser.add_argument("-s", "--submissionid", required=True, help="Submission ID")
+          parser.add_argument("-r", "--results", required=True, help="download results info")
+          parser.add_argument("-o", "--output", required=True, help="download results info")
+          parser.add_argument("-c", "--synapse_config", required=True, help="credentials file")
+          args = parser.parse_args()
+          syn = synapseclient.Synapse(configPath=args.synapse_config)
+          syn.login()
+          sub = syn.getSubmission(args.submissionid, downloadLocation=".")
+          if sub.entity.concreteType!='org.sagebionetworks.repo.model.docker.DockerRepository':
+            raise Exception('Expected DockerRepository type but found '+sub.entity.concreteType)
+          result = {'docker_repository':sub.get("dockerRepositoryName",""),'docker_digest':sub.get("dockerDigest",""),'entityid':sub.entity.id}
+          
+          with open(args.results, 'w') as o:
+            o.write(json.dumps(result))
+
+          submitterid = sub['userId'] if sub.get("teamId") is None else sub['teamId'] 
+          userids = {'main_userid': sub.userId, 'main_submitterId': submitterid}
+          with open(args.output, 'w') as o:
+            o.write(json.dumps(userids))
+
+outputs:
+  - id: docker_repository
+    type: string
+    outputBinding:
+      glob: results.json
+      loadContents: true
+      outputEval: $(JSON.parse(self[0].contents)['docker_repository'])
+  - id: docker_digest
+    type: string
+    outputBinding:
+      glob: results.json
+      loadContents: true
+      outputEval: $(JSON.parse(self[0].contents)['docker_digest'])
+  - id: entityid
+    type: string
+    outputBinding:
+      glob: results.json
+      loadContents: true
+      outputEval: $(JSON.parse(self[0].contents)['entityid'])
+  - id: results
+    type: File
+    outputBinding:
+      glob: output.json

--- a/main_queue_wf.cwl
+++ b/main_queue_wf.cwl
@@ -1,0 +1,125 @@
+#!/usr/bin/env cwl-runner
+#
+# Express lane workflow
+# Inputs:
+#   submissionId: ID of the Synapse submission to process
+#   adminUploadSynId: ID of a folder accessible only to the submission queue administrator
+#   submitterUploadSynId: ID of a folder accessible to the submitter
+#   workflowSynapseId:  ID of the Synapse entity containing a reference to the workflow file(s)
+#
+cwlVersion: v1.0
+class: Workflow
+
+requirements:
+  - class: StepInputExpressionRequirement
+
+inputs:
+  - id: submissionId
+    type: int
+  - id: adminUploadSynId
+    type: string
+  - id: submitterUploadSynId
+    type: string
+  - id: workflowSynapseId
+    type: string
+  - id: synapseConfig
+    type: File
+
+# there are no output at the workflow engine level.  Everything is uploaded to Synapse
+outputs: []
+
+steps:
+
+  get_docker_submission:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out:
+      - id: filepath
+      - id: docker_repository
+      - id: docker_digest
+      - id: entity_id
+      - id: entity_type
+      - id: results
+
+  get_docker_config:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/get_docker_config.cwl
+    in:
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: 
+      - id: docker_registry
+      - id: docker_authentication
+
+#  download_goldstandard:
+#    run: https://raw.githubusercontent.com/Sage-Bionetworks/synapse-client-cwl-tools/v0.1/synapse-get-tool.cwl
+#    in:
+#      - id: synapseid
+#        #This is a dummy syn id, replace when you use your own workflow
+#        valueFrom: "syn18081597"
+#      - id: synapse_config
+#        source: "#synapseConfig"
+#    out:
+#      - id: filepath
+
+  validate_docker:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/validate_docker.cwl
+    in:
+      - id: docker_repository
+        source: "#get_docker_submission/docker_repository"
+      - id: docker_digest
+        source: "#get_docker_submission/docker_digest"
+      - id: synapse_config
+        source: "#synapseConfig"
+    out:
+      - id: results
+      - id: status
+      - id: invalid_reasons
+
+  annotate_docker_validation_with_output:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#validate_docker/results"
+      - id: to_public
+        default: true
+      - id: force_change_annotation_acl
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: [finished]
+
+  check_status:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/check_status.cwl
+    in:
+      - id: status
+        source: "#validate_docker/status"
+      - id: previous_annotation_finished
+        source: "#annotate_validation_with_output/finished"
+      - id: previous_email_finished
+        source: "#validation_email/finished"
+    out: [finished]
+
+  submit_to_challenge:
+    run: submit_to_challenge.cwl
+    in:
+      - id: status
+        source: "#validate_docker/status"
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: parentid
+        source: "#submitterUploadSynId"
+      - id: evaluationid
+        valueFrom: "9614390"
+      - id: previous_annotation_finished
+        source: "#annotate_docker_validation_with_output/finished"
+#      - id: previous_email_finished
+#        source: "#validation_email/finished"
+    out: []

--- a/submit_to_challenge.cwl
+++ b/submit_to_challenge.cwl
@@ -1,0 +1,71 @@
+#!/usr/bin/env cwl-runner
+#
+# Example score submission file
+#
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: python
+
+inputs:
+  - id: status
+    type: string
+  - id: submissionid
+    type: int
+  - id: synapse_config
+    type: File
+  - id: parentid
+    type: string
+  - id: evaluationid
+    type: string
+  - id: previous_annotation_finished
+    type: boolean?
+  - id: previous_email_finished
+    type: boolean?
+
+arguments:
+  - valueFrom: submit.py
+  - valueFrom: $(inputs.status)
+    prefix: -s
+  - valueFrom: submission.json
+    prefix: -r
+  - valueFrom: $(inputs.submissionid)
+    prefix: -i
+  - valueFrom: $(inputs.synapse_config.path)
+    prefix: -c
+  - valueFrom: $(inputs.parentid)
+    prefix: --parentid
+  - valueFrom: $(inputs.evaluationid)
+    prefix: -e
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: submit.py
+        entry: |
+          #!/usr/bin/env python
+          import synapseclient
+          import argparse
+          import json
+
+          parser = argparse.ArgumentParser()
+          parser.add_argument("-s", "--status", required=True, help="Submission status")
+          parser.add_argument("-r", "--results", required=True, help="Scoring results")
+          parser.add_argument("-i", "--submissionid", required=True, help="Submission ID")
+          parser.add_argument("-c", "--synapse_config", required=True, help="credentials file")
+          parser.add_argument("--parentid", required=True, help="Parent Id of submitter directory")
+          parser.add_argument("-e", "--evaluationid", required=True, help="Internal evaluation id")
+
+          args = parser.parse_args()
+          syn = synapseclient.Synapse(configPath=args.synapse_config)
+          syn.login()
+          if args.status == "VALIDATED":
+            submission_dict = {"submissionid": int(args.submissionid)}
+            with open(args.results, 'w') as json_file:
+              json_file.write(json.dumps(submission_dict))
+            submission_file = synapseclient.File(args.results, parentId=args.parentid)
+            submission_file_ent = syn.store(submission_file)
+            syn.submit(evaluation=args.evaluationid, entity=submission_file_ent, name=args.submissionid)
+          else:
+            raise ValueError("Submission not valid")
+outputs: []


### PR DESCRIPTION
**I would hold off on this PR until you test if the orchestrator can just be linked to the same queue on multiple machines** I will describe the tools and updates here.  In this update:

`docker_agent_workflow.cwl`:  the queue you have been using will no longer take direct submissions from participants, submissions will be done by a service account and this workflow will take a submission that is in form of json:
```{'submissionid': '11111'}```

`get_linked_submissionid.cwl`: This tool simply get the above json and extracts out the actual submission id that the participant submitted

`get_submission_docker.cwl`:  This is a tool that obtains the docker submission, It is unique because it adds the submitter and user Id of the actual participant so this information can be added to the leaderboard

`main_queue_wf.cwl` : This will be the main queue that the participants see, They will submit to this queue and it will generate a submission on their behalf to one of the queues.  **Missing**: The tool that selects which queue to submit to, right now it just defaults to one queue.

`submit_to_challenge.cwl`: This tool takes the submission to the main queue and write a json described above and submits that json file to the chosen internal evaluation queue.